### PR TITLE
Change markdown to markup

### DIFF
--- a/docs/MobileOrgv2.org
+++ b/docs/MobileOrgv2.org
@@ -22,8 +22,8 @@
     | Architecture |       |
     |--------------+-------|
 
-**** All Markdown
-     Markdown supported by Org should be also supported by MobileOrg. A preview
+**** All Markup
+     Markup supported by Org should be also supported by MobileOrg. A preview
      should be presented to the user whilst editing a note.
 
 ***** Links


### PR DESCRIPTION
Markdown is a specification for a system of markup, which is similar to org markup.  To reduce ambiguity, markup should be used instead of markdown.